### PR TITLE
Suporte ao PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2|^8.0",
         "illuminate/support": ">=6.0"
     },
     "require-dev": {


### PR DESCRIPTION
Adiciona suporte ao php 8.
Fui tentar usar em um projeto meu e fiquei me batendo até ver que não suportava php 8, tinha que ficar usando `composer install --ignore-platform-reqs`